### PR TITLE
feat: msec -> HH:mm:SS

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1,6 +1,21 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
+/***/ 1539:
+/***/ ((module) => {
+
+function formatDuration(durationInMs) {
+  const durationInSec = durationInMs / 1000;
+  const hours = Math.floor(durationInSec / 3600);
+  const minutes = Math.floor((durationInSec % 3600) / 60);
+  const seconds = Math.floor(durationInSec % 60);
+  return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
+}
+
+module.exports = { formatDuration };
+
+/***/ }),
+
 /***/ 7351:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
@@ -6677,112 +6692,6 @@ module.exports = exports.default;
 
 /***/ }),
 
-/***/ 8917:
-/***/ ((module, exports, __nccwpck_require__) => {
-
-"use strict";
-
-
-var _interopRequireDefault = (__nccwpck_require__(3286)["default"]);
-Object.defineProperty(exports, "__esModule", ({
-  value: true
-}));
-exports["default"] = formatDuration;
-var _index = __nccwpck_require__(9307);
-var _index2 = _interopRequireDefault(__nccwpck_require__(618));
-var defaultFormat = ['years', 'months', 'weeks', 'days', 'hours', 'minutes', 'seconds'];
-
-/**
- * @name formatDuration
- * @category Common Helpers
- * @summary Formats a duration in human-readable format
- *
- * @description
- * Return human-readable duration string i.e. "9 months 2 days"
- *
- * @param {Duration} duration - the duration to format
- * @param {Object} [options] - an object with options.
- * @param {string[]} [options.format=['years', 'months', 'weeks', 'days', 'hours', 'minutes', 'seconds']] - the array of units to format
- * @param {boolean} [options.zero=false] - should zeros be included in the output?
- * @param {string} [options.delimiter=' '] - delimiter string
- * @param {Locale} [options.locale=defaultLocale] - the locale object. See [Locale]{@link https://date-fns.org/docs/Locale}
- * @returns {string} the formatted date string
- * @throws {TypeError} 1 argument required
- *
- * @example
- * // Format full duration
- * formatDuration({
- *   years: 2,
- *   months: 9,
- *   weeks: 1,
- *   days: 7,
- *   hours: 5,
- *   minutes: 9,
- *   seconds: 30
- * })
- * //=> '2 years 9 months 1 week 7 days 5 hours 9 minutes 30 seconds'
- *
- * @example
- * // Format partial duration
- * formatDuration({ months: 9, days: 2 })
- * //=> '9 months 2 days'
- *
- * @example
- * // Customize the format
- * formatDuration(
- *   {
- *     years: 2,
- *     months: 9,
- *     weeks: 1,
- *     days: 7,
- *     hours: 5,
- *     minutes: 9,
- *     seconds: 30
- *   },
- *   { format: ['months', 'weeks'] }
- * ) === '9 months 1 week'
- *
- * @example
- * // Customize the zeros presence
- * formatDuration({ years: 0, months: 9 })
- * //=> '9 months'
- * formatDuration({ years: 0, months: 9 }, { zero: true })
- * //=> '0 years 9 months'
- *
- * @example
- * // Customize the delimiter
- * formatDuration({ years: 2, months: 9, weeks: 3 }, { delimiter: ', ' })
- * //=> '2 years, 9 months, 3 weeks'
- */
-function formatDuration(duration, options) {
-  var _ref, _options$locale, _options$format, _options$zero, _options$delimiter;
-  if (arguments.length < 1) {
-    throw new TypeError("1 argument required, but only ".concat(arguments.length, " present"));
-  }
-  var defaultOptions = (0, _index.getDefaultOptions)();
-  var locale = (_ref = (_options$locale = options === null || options === void 0 ? void 0 : options.locale) !== null && _options$locale !== void 0 ? _options$locale : defaultOptions.locale) !== null && _ref !== void 0 ? _ref : _index2.default;
-  var format = (_options$format = options === null || options === void 0 ? void 0 : options.format) !== null && _options$format !== void 0 ? _options$format : defaultFormat;
-  var zero = (_options$zero = options === null || options === void 0 ? void 0 : options.zero) !== null && _options$zero !== void 0 ? _options$zero : false;
-  var delimiter = (_options$delimiter = options === null || options === void 0 ? void 0 : options.delimiter) !== null && _options$delimiter !== void 0 ? _options$delimiter : ' ';
-  if (!locale.formatDistance) {
-    return '';
-  }
-  var result = format.reduce(function (acc, unit) {
-    var token = "x".concat(unit.replace(/(^.)/, function (m) {
-      return m.toUpperCase();
-    }));
-    var value = duration[unit];
-    if (typeof value === 'number' && (zero || duration[unit])) {
-      return acc.concat(locale.formatDistance(token, value));
-    }
-    return acc;
-  }, []).join(delimiter);
-  return result;
-}
-module.exports = exports.default;
-
-/***/ }),
-
 /***/ 6801:
 /***/ ((module, exports, __nccwpck_require__) => {
 
@@ -13159,7 +13068,8 @@ const github = __nccwpck_require__(5438)
 
 const format = __nccwpck_require__(2168)
 const parseISO = __nccwpck_require__(3390)
-const formatDuration = __nccwpck_require__(8917)
+
+const { formatDuration } = __nccwpck_require__(1539)
 
 async function run(owner, repo, workflowName, token) {
   try {
@@ -13181,11 +13091,7 @@ async function run(owner, repo, workflowName, token) {
         continue
       }
 
-      const durationInSec = duration.run_duration_ms / 1000;
-      const hours = Math.floor(durationInSec / 3600);
-      const minutes = Math.floor((durationInSec % 3600) / 60);
-      const seconds = Math.floor(durationInSec % 60);
-      const durationFormatted = `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
+      const durationFormatted = formatDuration(duration.run_duration_ms)
       core.info(`${run.id}, ${durationFormatted}, ${format(parseISO(run.created_at), 'yyyy/MM/dd HH:mm:ss')}`)
     }
   } catch(error) {

--- a/durations.js
+++ b/durations.js
@@ -1,0 +1,9 @@
+function formatDuration(durationInMs) {
+  const durationInSec = durationInMs / 1000;
+  const hours = Math.floor(durationInSec / 3600);
+  const minutes = Math.floor((durationInSec % 3600) / 60);
+  const seconds = Math.floor(durationInSec % 60);
+  return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
+}
+
+module.exports = { formatDuration };

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const github = require('@actions/github')
 
 const format = require('date-fns/format')
 const parseISO = require('date-fns/parseISO')
+const formatDuration = require('date-fns/formatDuration')
 
 async function run(owner, repo, workflowName, token) {
   try {
@@ -19,7 +20,17 @@ async function run(owner, repo, workflowName, token) {
         repo,
         run_id: run.id
       })
-      core.info(`${run.id}: ${duration.run_duration_ms}ms: ${format(parseISO(run.created_at), 'yyyy/MM/dd HH:mm:ss')}`)
+      // run.idが取得できない、duration.run_duration_msが取得できない、run.created_atが取得できない場合は次のループに移る
+      if (!run.id || !duration.run_duration_ms || !run.created_at) {
+        continue
+      }
+
+      const durationInSec = duration.run_duration_ms / 1000;
+      const hours = Math.floor(durationInSec / 3600);
+      const minutes = Math.floor((durationInSec % 3600) / 60);
+      const seconds = Math.floor(durationInSec % 60);
+      const durationFormatted = `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
+      core.info(`${run.id}, ${durationFormatted}, ${format(parseISO(run.created_at), 'yyyy/MM/dd HH:mm:ss')}`)
     }
   } catch(error) {
     core.error(error)

--- a/index.js
+++ b/index.js
@@ -3,7 +3,8 @@ const github = require('@actions/github')
 
 const format = require('date-fns/format')
 const parseISO = require('date-fns/parseISO')
-const formatDuration = require('date-fns/formatDuration')
+
+const { formatDuration } = require('./durations')
 
 async function run(owner, repo, workflowName, token) {
   try {
@@ -25,11 +26,7 @@ async function run(owner, repo, workflowName, token) {
         continue
       }
 
-      const durationInSec = duration.run_duration_ms / 1000;
-      const hours = Math.floor(durationInSec / 3600);
-      const minutes = Math.floor((durationInSec % 3600) / 60);
-      const seconds = Math.floor(durationInSec % 60);
-      const durationFormatted = `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
+      const durationFormatted = formatDuration(duration.run_duration_ms)
       core.info(`${run.id}, ${durationFormatted}, ${format(parseISO(run.created_at), 'yyyy/MM/dd HH:mm:ss')}`)
     }
   } catch(error) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

```
- 新機能: `formatDuration`関数を追加しました。これにより、実行時間を"hh:mm:ss"形式で表示できるようになりました。
- リファクタリング: `index.js`にて、ログ情報の出力前に`run.id`、`duration.run_duration_ms`、`run.created_at`の存在チェックを追加しました。これにより、ログ出力の安全性が向上しました。
```
<!-- end of auto-generated comment: release notes by coderabbit.ai -->