### PR TITLE
feat: save file actions-duration.json

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -11,3 +11,4 @@ jobs:
           repository_name: 'mas0061/nuxt3-practice'
           workflow_name: 'ci.yml'
           token: ${{ secrets.GITHUB_TOKEN }}
+      - run: echo "$(cat actions-duration.json | jq .)"

--- a/dist/index.js
+++ b/dist/index.js
@@ -9881,6 +9881,7 @@ var __webpack_exports__ = {};
 (() => {
 const core = __nccwpck_require__(2186)
 const github = __nccwpck_require__(5438)
+const fs = __nccwpck_require__(7147)
 
 const { logWorkflowDurations } = __nccwpck_require__(5606)
 
@@ -9912,6 +9913,12 @@ const durations = logWorkflowDurations(octokit, owner, repo, workflowName).catch
 
 // durationsを1つずつcore.infoで出力する
 durations.then((durations) => {
+  const data = JSON.stringify(durations)
+  fs.writeFile('actions-duration.json', data, (err) => {
+    if (err) throw err
+    core.info('The file has been saved!')
+  })
+
   durations.forEach((duration) => {
     core.info(`${duration.id}, ${duration.duration}, ${duration.created_at}`)
   })

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 const core = require('@actions/core')
 const github = require('@actions/github')
+const fs = require('fs')
 
 const { logWorkflowDurations } = require('./logWorkflowDurations')
 
@@ -31,6 +32,12 @@ const durations = logWorkflowDurations(octokit, owner, repo, workflowName).catch
 
 // durationsを1つずつcore.infoで出力する
 durations.then((durations) => {
+  const data = JSON.stringify(durations)
+  fs.writeFile('actions-duration.json', data, (err) => {
+    if (err) throw err
+    core.info('The file has been saved!')
+  })
+
   durations.forEach((duration) => {
     core.info(`${duration.id}, ${duration.duration}, ${duration.created_at}`)
   })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->


### Summary by CodeRabbit

- 新機能: 'fs'モジュールを利用して、'durations'データを'actions-duration.json'という名前のファイルに書き込む機能が追加されました。ファイルが保存されたことを示すメッセージがログに表示されます。
- マイナーな変更: GitHub Actionsのワークフローに、'actions-duration.json'ファイルの内容を表示する新しいステップが追加されました。この変更はコードのロジックや制御構造には影響を与えません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->